### PR TITLE
Fix minor typo

### DIFF
--- a/config_HD4600_4400_4200.plist
+++ b/config_HD4600_4400_4200.plist
@@ -335,7 +335,7 @@
 				<key>Disabled</key>
 				<true/>
 				<key>Name</key>
-				<string>AppleIntelFrameBufferAzul</string>
+				<string>AppleIntelFramebufferAzul</string>
 				<key>Find</key>
 				<data>AQAAAEAAAADWAAAABQUAAA==</data>
 				<key>Replace</key>

--- a/config_HD5000_5100_5200.plist
+++ b/config_HD5000_5100_5200.plist
@@ -330,7 +330,7 @@
 				<key>Disabled</key>
 				<true/>
 				<key>Name</key>
-				<string>AppleIntelFrameBufferAzul</string>
+				<string>AppleIntelFramebufferAzul</string>
 				<key>Find</key>
 				<data>AQAAAEAAAADWAAAABQUAAA==</data>
 				<key>Replace</key>


### PR DESCRIPTION
I’m not sure Clover cares, but the difference in capitalization shows up in my test tool.