### PR TITLE
add LVDS to eDP patch at port 0000 for 0x191e0000, 0x19160000, 0x19260000, 0x19270000, 0x191b0000, 0x19160002, 0x19260002, 0x191e0003, 0x19260004, 0x19270004, 0x193b0005 credit syscl

### DIFF
--- a/config_HD520_530_540.plist
+++ b/config_HD520_530_540.plist
@@ -324,6 +324,18 @@
 				<key>Replace</key>
 				<data>AQAA6xc=</data>
 			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>eDP, port 0000, 0x191e0000, 0x19160000, 0x19260000, 0x19270000, 0x191b0000, 0x19160002, 0x19260002, 0x191e0003, 0x19260004, 0x19270004, 0x193b0005 credit syscl</string>
+				<key>Disabled</key>
+				<true/>
+				<key>Find</key>
+				<data>AAAIAAIAAACYAAAAAQUJAAAEAAA=</data>
+				<key>Name</key>
+				<string>AppleIntelSKLGraphicsFramebuffer</string>
+				<key>Replace</key>
+				<data>AAAIAAQAAACYAAAAAQUJAAAEAAA=</data>
+			</dict>
 		</array>
 	</dict>
 	<key>RtVariables</key>

--- a/config_HD520_530_540.plist
+++ b/config_HD520_530_540.plist
@@ -334,7 +334,7 @@
 				<key>Name</key>
 				<string>AppleIntelSKLGraphicsFramebuffer</string>
 				<key>Replace</key>
-				<data>AAAIAAQAAACYAAAAAQUJAAAEAAA=</data>
+				<data>AAAIAAAEAACYAAAAAQUJAAAEAAA=</data>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
at port 0000 laptops use eDP instead of LVDS. This patch simply correct the internal display connector type.

syscl