### PR TITLE
Master

### DIFF
--- a/config_HD550.plist
+++ b/config_HD550.plist
@@ -248,7 +248,7 @@
 	<key>Graphics</key>
 	<dict>
 		<key>ig-platform-id</key>
-		<string>0x19160000</string>
+		<string>0x19260000</string>
 		<key>Inject</key>
 		<dict>
 			<key>ATI</key>


### PR DESCRIPTION
1. Iris Graphics uses different ig-platform-id, otherwise will cause graphics
flickering and glitches