### PR TITLE
Update SSDT-IGPU.dsl

### DIFF
--- a/hotpatch/SSDT-IGPU.dsl
+++ b/hotpatch/SSDT-IGPU.dsl
@@ -141,6 +141,49 @@ DefinitionBlock("", "SSDT", 2, "hack", "IGPU", 0)
                 "AAPL,ig-platform-id", Buffer() { 0x04, 0x00, 0x26, 0x16 },
                 "hda-gfx", Buffer() { "onboard-1" },
             },
+            // Kaby Lake/HD615
+            0x591e, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x1e, 0x59 },
+                "model", Buffer() { "Intel HD Graphics 615" },
+                "hda-gfx", Buffer() { "onboard-1" },
+            },
+            // Kaby Lake/HD620
+            0x5916, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x16, 0x59 },
+                "model", Buffer() { "Intel HD Graphics 620" },
+                "hda-gfx", Buffer() { "onboard-1" },
+            },
+            // Kaby Lake-R/HD620
+            0x5917, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x16, 0x59 },
+                "model", Buffer() { "Intel UHD Graphics 620" },
+                "hda-gfx", Buffer() { "onboard-1" },
+                "device-id", Buffer() { 0x16, 0x59, 0x00, 0x00 },
+            },
+            // KabyLake/HD630 mobile
+            0x591b, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x1b, 0x59 },
+                "model", Buffer() { "Intel HD Graphics 630" },
+                "hda-gfx", Buffer() { "onboard-1" },
+            },
+            // Kaby Lake/HD640
+            0x5926, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x02, 0x00, 0x26, 0x59 },
+                "model", Buffer() { "Intel Iris Plus Graphics 640" },
+                "hda-gfx", Buffer() { "onboard-1" },
+            },
+            // Kaby Lake/HD650
+            0x5927, 0, Package()
+            {
+                "AAPL,ig-platform-id", Buffer() { 0x02, 0x00, 0x26, 0x59 },
+                "model", Buffer() { "Intel Iris Plus Graphics 650" },
+                "hda-gfx", Buffer() { "onboard-1" },
+            },
         })
         // Injection tables for desktops
         Name(DESK, Package()
@@ -308,54 +351,11 @@ DefinitionBlock("", "SSDT", 2, "hack", "IGPU", 0)
                 "hda-gfx", Buffer() { "onboard-1" },
                 "RM,device-id", Buffer() { 0x3b, 0x19, 0x00, 0x00 },
             },
-            // Kaby Lake/HD615
-            0x591e, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x1e, 0x59 },
-                "model", Buffer() { "Intel HD Graphics 615" },
-                "hda-gfx", Buffer() { "onboard-1" },
-            },
-            // Kaby Lake/HD620
-            0x5916, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x16, 0x59 },
-                "model", Buffer() { "Intel HD Graphics 620" },
-                "hda-gfx", Buffer() { "onboard-1" },
-            },
-            // Kaby Lake-R/HD620
-            0x5917, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x16, 0x59 },
-                "model", Buffer() { "Intel HD Graphics 620" },
-                "hda-gfx", Buffer() { "onboard-1" },
-                "device-id", Buffer() { 0x16, 0x59, 0x00, 0x00 },
-            },
             // Kaby Lake/HD630
             0x5912, 0, Package()
             {
                 "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x12, 0x59 },
                 "model", Buffer() { "Intel HD Graphics 630" },
-                "hda-gfx", Buffer() { "onboard-1" },
-            },
-            // KabyLake/HD630 mobile?
-            0x591b, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x00, 0x00, 0x1b, 0x59 },
-                "model", Buffer() { "Intel HD Graphics 630" },
-                "hda-gfx", Buffer() { "onboard-1" },
-            },
-            // Kaby Lake/HD640
-            0x5926, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x02, 0x00, 0x26, 0x59 },
-                "model", Buffer() { "Intel Iris Plus Graphics 640" },
-                "hda-gfx", Buffer() { "onboard-1" },
-            },
-            // Kaby Lake/HD650
-            0x5927, 0, Package()
-            {
-                "AAPL,ig-platform-id", Buffer() { 0x02, 0x00, 0x26, 0x59 },
-                "model", Buffer() { "Intel Iris Plus Graphics 650" },
                 "hda-gfx", Buffer() { "onboard-1" },
             },
         })
@@ -386,24 +386,24 @@ DefinitionBlock("", "SSDT", 2, "hack", "IGPU", 0)
                         If (0 == Local2) // lowres
                         {
                             Local1 = LAPL
-                            Local0 = Match(Local0, MEQ, GDID, MTR, 0, 0)
+                            Local0 = Match(LAPL, MEQ, GDID, MTR, 0, 0)
                             if (Ones != Local0) { Break }
                         }
                         ElseIf (1 == Local2) // hires
                         {
                             Local1 = LAPH
-                            Local0 = Match(Local0, MEQ, GDID, MTR, 0, 0)
+                            Local0 = Match(LAPH, MEQ, GDID, MTR, 0, 0)
                             if (Ones != Local0) { Break }
                         }
                         // not found in LAPL or LAPH, use generic
                         Local1 = LAPG
-                        Local0 = Match(Local0, MEQ, GDID, MTR, 0, 0)
+                        Local0 = Match(LAPG, MEQ, GDID, MTR, 0, 0)
                         if (Ones != Local0) { Break }
                     }
                 }
                 // search desktop table
                 Local1 = DESK
-                Local0 = Match(Local0, MEQ, GDID, MTR, 0, 0)
+                Local0 = Match(DESK, MEQ, GDID, MTR, 0, 0)
                 Break
             }
             // unrecognized device... inject nothing in this case


### PR DESCRIPTION
* Automatic matching did not work on my machine, referring to the direct definition blocks fixes this (and is more clear to read in code)
* Moved mobile Kabylake chipsets under laptop generic instead of desktop
* Fixed naming of 0x5917 to Intel UHD Graphics 620 as per Intel data