### PR TITLE
Updated lid wake patch for 0x0a2e0008 on 10.13+

### DIFF
--- a/config_HD4600_4400_4200.plist
+++ b/config_HD4600_4400_4200.plist
@@ -478,9 +478,25 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Enable internal display after sleep for 0x0a2e0008, credit syscl/lighting/Yating Zhou</string>
+				<string>Enable internal display after sleep for 0x0a2e0008, credit syscl/lighting/Yating Zhou 10.10.2-10.12.x</string>
 				<key>Disabled</key>
 				<true/>
+				<key>MatchOS</key>
+				<string>10.10.x,10.11.x, 10.12.x</string>
+				<key>Name</key>
+				<string>com.apple.driver.AppleIntelFramebufferAzul</string>
+				<key>Find</key>
+				<data>AQAAAEAAAAAeAAAABQUJAQ==</data>
+				<key>Replace</key>
+				<data>AQAAAEAAAAAPAAAABQUJAQ==</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Enable internal display after sleep for 0x0a2e0008 (c) syscl 10.13.x</string>
+				<key>Disabled</key>
+				<true/>
+				<key>MatchOS</key>
+				<string>10.13.x</string>
 				<key>Name</key>
 				<string>com.apple.driver.AppleIntelFramebufferAzul</string>
 				<key>Find</key>


### PR DESCRIPTION
The framebuffer of 0x0a2e0008 has changed which leads to internal
display void after resume from sleep. By comparing the bytes changed, I
slightly modified the lid wake patch and made my M3800 worked again on
10.13+.