### PR TITLE
Updated lid wake patch for 0x0a2e0008 on 10.13+

### DIFF
--- a/config_HD4600_4400_4200.plist
+++ b/config_HD4600_4400_4200.plist
@@ -478,15 +478,31 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Enable internal display after sleep for 0x0a2e0008, credit syscl/lighting/Yating Zhou</string>
+				<string>Enable internal display after sleep for 0x0a2e0008 on 10.10.2-10.12.x (c) syscl</string>
 				<key>Disabled</key>
 				<true/>
+				<key>MatchOS</key>
+				<string>10.10.x,10.11.x,10.12.x</string>
 				<key>Name</key>
 				<string>com.apple.driver.AppleIntelFramebufferAzul</string>
 				<key>Find</key>
 				<data>AQAAAEAAAAAeAAAABQUJAQ==</data>
 				<key>Replace</key>
 				<data>AQAAAEAAAAAPAAAABQUJAQ==</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Enable internal display after sleep for 0x0a2e0008 on 10.13.x (c) syscl</string>
+				<key>Disabled</key>
+				<true/>
+				<key>MatchOS</key>
+				<string>10.13.x</string>
+				<key>Name</key>
+				<string>com.apple.driver.AppleIntelFramebufferAzul</string>
+				<key>Find</key>
+				<data>AQAAAEAAAAAeAgAABQUJAQ==</data>
+				<key>Replace</key>
+				<data>AQAAAEAAAAAfAgAABQUJAQ==</data>
 			</dict>
 			<dict>
 				<key>Comment</key>


### PR DESCRIPTION
The frame buffer of 0x0a2e0008 on 10.13.x has slightly changed, thus
lead to the previous lid wake patch invalid. And through the
experimental on Dell Precision M3800(QHD+), I have brought a new
version of lid wake patch for 0x0a2e0008 on 10.13+.