### PR TITLE
Extended _xcpm_idle instant reboot patch to High Sierra (10.13.x+)

### DIFF
--- a/config_HD4600_4400_4200.plist
+++ b/config_HD4600_4400_4200.plist
@@ -595,13 +595,13 @@
 		<array>
 			<dict>
 				<key>Comment</key>
-				<string>MSR 0xE2 _xcpm_idle instant reboot(c) Pike R. Alpha</string>
+				<string>MSR 0xE2 _xcpm_idle instant reboot (c) Pike R. Alpha, syscl</string>
 				<key>Disabled</key>
 				<false/>
 				<key>Find</key>
 				<data>ILniAAAADzA=</data>
 				<key>MatchOS</key>
-				<string>10.12.x,10.11.x</string>
+				<string>10.13.x,10.12.x,10.11.x</string>
 				<key>Replace</key>
 				<data>ILniAAAAkJA=</data>
 			</dict>


### PR DESCRIPTION
This patch is first discovered by Pike. R. Alpha and syscl to enable
full HWP. By comparing the bytes, the kernel patch on 10.13.x remains
unchanged, thus I extended this patch to 10.13.x+ as well.