### PR TITLE
Update SSDT-XOSI

### DIFF
--- a/hotpatch/SSDT-XOSI.dsl
+++ b/hotpatch/SSDT-XOSI.dsl
@@ -5,14 +5,14 @@ DefinitionBlock("", "SSDT", 2, "hack", "_XOSI", 0)
 {
 #endif
     // All _OSI calls in DSDT are routed to XOSI...
-    // As written, this XOSI simulates "Windows 2012" (which is Windows 8)
+    // As written, this XOSI simulates "Windows 2015" (which is Windows 10)
     // Note: According to ACPI spec, _OSI("Windows") must also return true
     //  Also, it should return true for all previous versions of Windows.
     Method(XOSI, 1)
     {
         // simulation targets
         // source: (google 'Microsoft Windows _OSI')
-        //  http://download.microsoft.com/download/7/E/7/7E7662CF-CBEA-470B-A97E-CE7CE0D98DC2/WinACPI_OSI.docx
+        //  https://docs.microsoft.com/en-us/windows-hardware/drivers/acpi/winacpi-osi
         Local0 = Package()
         {
             "Windows",              // generic Windows query
@@ -25,8 +25,12 @@ DefinitionBlock("", "SSDT", 2, "hack", "_XOSI", 0)
             "Windows 2006.1",       // Windows Server 2008
             "Windows 2009",         // Windows 7/Windows Server 2008 R2
             "Windows 2012",         // Windows 8/Windows Server 2012
-            //"Windows 2013",       // Windows 8.1/Windows Server 2012 R2
-            //"Windows 2015",       // Windows 10/Windows Server TP
+            "Windows 2013",         // Windows 8.1/Windows Server 2012 R2
+            "Windows 2015",         // Windows 10/Windows Server TP
+            //"Windows 2016",       // Windows 10, version 1607
+            //"Windows 2017",       // Windows 10, version 1703
+            //"Windows 2017.2",     // Windows 10, version 1709
+            //"Windows 2018",       // Windows 10, version 1803
         }
         Return (Ones != Match(Local0, MEQ, Arg0, MTR, 0, 0))
     }


### PR DESCRIPTION
With newer machines (Skylake+), emulating Windows 2015 is probably the best.
Some new machines (not very common) use newer Windows identifiers in ACPI. They are commented out.
Updated _OSI data source URL, as existing one doesn't contain up-to-date information.