### PR TITLE
Add whitelist patch for Brcm4360 on 10.13.x

### DIFF
--- a/hotpatch/config.plist
+++ b/hotpatch/config.plist
@@ -916,6 +916,18 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
+				<string>AirPortBrcm4360 whitelist patch (board-id), 10.13.x, credit RehabMan</string>
+				<key>MatchOS</key>
+				<string>10.13.x</string>
+				<key>Name</key>
+				<string>com.apple.driver.AirPort.Brcm4360</string>
+				<key>Find</key>
+				<data>SDtF4HUU</data>
+				<key>Replace</key>
+				<data>/8OQkJCQ</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
 				<string>10.9.5 5Ghz US FCC, svko</string>
 				<key>MatchOS</key>
 				<string>10.9.5</string>


### PR DESCRIPTION
Tested with **10.13.4**. Original patch for **10.13.beta9**.

Source: https://www.tonymacx86.com/threads/readme-common-problems-in-10-13-high-sierra.233582/