### PR TITLE
Add option in SSDT-RMCF.dsl to activate GPRW/UPRW (wake on USB) patches

### DIFF
--- a/hotpatch/SSDT-GPRW.dsl
+++ b/hotpatch/SSDT-GPRW.dsl
@@ -5,6 +5,7 @@ DefinitionBlock("", "SSDT", 2, "hack", "_GPRW", 0)
 {
 #endif
     External(XPRW, MethodObj)
+    External(RMCF.DWOU, IntObj)
 
     // In DSDT, native GPRW is renamed to XPRW with Clover binpatch.
     // As a result, calls to GPRW land here.
@@ -13,8 +14,14 @@ DefinitionBlock("", "SSDT", 2, "hack", "_GPRW", 0)
     // of the return package.
     Method(GPRW, 2)
     {
-        If (0x6d == Arg0) { Return (Package() { 0x6d, 0, }) }
-        If (0x0d == Arg0) { Return (Package() { 0x0d, 0, }) }
+        If (CondRefOf(\RMCF.DWOU))
+        {
+            If (\RMCF.DWOU)
+            {
+                If (0x6d == Arg0) { Return (Package() { 0x6d, 0, }) }
+                If (0x0d == Arg0) { Return (Package() { 0x0d, 0, }) }
+            }
+        }
         Return (XPRW(Arg0, Arg1))
     }
 #ifndef NO_DEFINITIONBLOCK

--- a/hotpatch/SSDT-RMCF.dsl
+++ b/hotpatch/SSDT-RMCF.dsl
@@ -112,6 +112,11 @@ DefinitionBlock("", "SSDT", 2, "hack", "_RMCF", 0)
         // 1: Ivy/Sandy
         // 2: Haswell/Broadwell/Skylake/KabyLake
         Name(FBTP, 0)
+        
+        // DWOU: Disable wake on USB
+        // 1: Disable wake on USB
+        // 0: Do not disable wake on USB
+        Name(DWOU, 0)
     }
 #ifndef NO_DEFINITIONBLOCK
 }

--- a/hotpatch/SSDT-UPRW.dsl
+++ b/hotpatch/SSDT-UPRW.dsl
@@ -5,6 +5,7 @@ DefinitionBlock("", "SSDT", 2, "hack", "_UPRW", 0)
 {
 #endif
     External(XPRW, MethodObj)
+    External(RMCF.DWOU, IntObj)
 
     // In DSDT, native UPRW is renamed to XPRW with Clover binpatch.
     // As a result, calls to UPRW land here.
@@ -13,8 +14,14 @@ DefinitionBlock("", "SSDT", 2, "hack", "_UPRW", 0)
     // of the return package.
     Method(UPRW, 2)
     {
-        If (0x6d == Arg0) { Return (Package() { 0x6d, 0, }) }
-        If (0x0d == Arg0) { Return (Package() { 0x0d, 0, }) }
+        If (CondRefOf(\RMCF.DWOU))
+        {
+            If (\RMCF.DWOU)
+            {
+                If (0x6d == Arg0) { Return (Package() { 0x6d, 0, }) }
+                If (0x0d == Arg0) { Return (Package() { 0x0d, 0, }) }
+            }
+        }
         Return (XPRW(Arg0, Arg1))
     }
 #ifndef NO_DEFINITIONBLOCK


### PR DESCRIPTION
Wake on USB (GPRW, UPRW) patches can be easily controlled via a new IntObj (DWOU) in Device(RMCF). 