### PR TITLE
Add Windows 2018.2 to SSDT-XOSI

### DIFF
--- a/hotpatch/SSDT-XOSI.dsl
+++ b/hotpatch/SSDT-XOSI.dsl
@@ -31,6 +31,7 @@ DefinitionBlock("", "SSDT", 2, "hack", "_XOSI", 0)
             //"Windows 2017",       // Windows 10, version 1703
             //"Windows 2017.2",     // Windows 10, version 1709
             //"Windows 2018",       // Windows 10, version 1803
+            //"Windows 2018.2",     // Windows 10, version 1809
         }
         Return (Ones != Match(Local0, MEQ, Arg0, MTR, 0, 0))
     }


### PR DESCRIPTION
When a major Windows release comes out, it's added to Microsoft's _OSI spec.
Added to the SSDT to support new machines shipped with build 1809.
That said, even new Coffee Lake machines often check for "Windows 2015" at most... Some OEMs do adopt new releases in their ACPI configuration.