### PR TITLE
Disable panic kext logging on 10.14.4-10.14.5

### DIFF
--- a/config_HD3000_1366x768.plist
+++ b/config_HD3000_1366x768.plist
@@ -468,13 +468,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD3000_1366x768_7series.plist
+++ b/config_HD3000_1366x768_7series.plist
@@ -479,13 +479,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD3000_1600x900.plist
+++ b/config_HD3000_1600x900.plist
@@ -470,13 +470,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD3000_1600x900_7series.plist
+++ b/config_HD3000_1600x900_7series.plist
@@ -481,13 +481,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD4000_1366x768.plist
+++ b/config_HD4000_1366x768.plist
@@ -462,13 +462,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD4000_1366x768_6series.plist
+++ b/config_HD4000_1366x768_6series.plist
@@ -473,13 +473,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD4000_1600x900.plist
+++ b/config_HD4000_1600x900.plist
@@ -472,13 +472,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD4000_1600x900_6series.plist
+++ b/config_HD4000_1600x900_6series.plist
@@ -483,13 +483,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD4600_4400_4200.plist
+++ b/config_HD4600_4400_4200.plist
@@ -475,13 +475,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD5000_5100_5200.plist
+++ b/config_HD5000_5100_5200.plist
@@ -464,13 +464,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD510.plist
+++ b/config_HD510.plist
@@ -496,13 +496,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD515_520_530_540.plist
+++ b/config_HD515_520_530_540.plist
@@ -485,13 +485,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD5300_5500_6000.plist
+++ b/config_HD5300_5500_6000.plist
@@ -458,13 +458,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD550_P530.plist
+++ b/config_HD550_P530.plist
@@ -492,13 +492,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD5600.plist
+++ b/config_HD5600.plist
@@ -461,13 +461,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD615_620_630_640_650.plist
+++ b/config_HD615_620_630_640_650.plist
@@ -496,13 +496,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_HD615_620_630_640_650_spoof.plist
+++ b/config_HD615_620_630_640_650_spoof.plist
@@ -498,13 +498,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_UHD630.plist
+++ b/config_UHD630.plist
@@ -490,13 +490,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 	</dict>

--- a/config_patches.plist
+++ b/config_patches.plist
@@ -30,13 +30,23 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>Disable panic kext logging on 10.14 release kernel (credit vit9696)</string>
+				<string>Disable panic kext logging on 10.14.0-10.14.3 release kernel (credit vit9696)</string>
 				<key>MatchOS</key>
-				<string>10.14.x</string>
+				<string>10.14.0,10.14.1,10.14.2,10.14.3</string>
 				<key>Find</key>
 				<data>igKEwHRC</data>
 				<key>Replace</key>
 				<data>igKEwOtC</data>
+			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable panic kext logging on 10.14.4-10.14.5 release kernel</string>
+				<key>MatchOS</key>
+				<string>10.14.4,10.14.5</string>
+				<key>Find</key>
+				<data>AIoChMB0</data>
+				<key>Replace</key>
+				<data>AIoChMDr</data>
 			</dict>
 		</array>
 		<key>KextsToPatch</key>


### PR DESCRIPTION
This patch is taken from https://applelife.ru/threads/ustanovka-macos-high-sierra-10-13-na-intel-pc.2210706/page-358#post-686953

It works for me on macOS 10.14.5, I'm using config_HD4600_4400_4200.plist.

Bytheway, thanks for great configs!